### PR TITLE
soc: update Kconfig.soc default

### DIFF
--- a/soc/xlnx/mbv32/Kconfig.soc
+++ b/soc/xlnx/mbv32/Kconfig.soc
@@ -8,4 +8,4 @@ config SOC_MBV32
 	bool
 
 config SOC
-	default "mbv32"
+	default "mbv32" if SOC_MBV32


### PR DESCRIPTION
Updated Kconfig file to only use Microblaze V board when target is requested