### PR TITLE
drivers: intc: fix for interrupt handling

### DIFF
--- a/drivers/interrupt_controller/intc_xlnx.c
+++ b/drivers/interrupt_controller/intc_xlnx.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023 - 2024 Advanced Micro Devices, Inc. (AMD)
  * Copyright (c) 2023 Alp Sayin <alpsayin@gmail.com>
+ * Copyright (c) 2026 Bittium Wireless oy, Saku Glumoff <saku.glumoff@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -187,38 +188,45 @@ int32_t xlnx_intc_irq_start(void)
 
 static void xlnx_irq_handler(const void *arg)
 {
-	uint32_t irq, irq_mask;
+	uint32_t irq, irq_mask, irq_pending;
 	struct _isr_table_entry *ite;
 	uint32_t level = POINTER_TO_UINT(arg);
 
 	/* Get the IRQ number generating the interrupt */
-	irq_mask = xlnx_intc_irq_pending();
+	irq_pending = xlnx_intc_irq_pending();
+	irq_mask = irq_pending;
 	irq = find_lsb_set(irq_mask);
 
-	/*
-	 * If the IRQ is out of range, call z_irq_spurious.
-	 * A call to z_irq_spurious will not return.
-	 */
-	if (irq == 0U || irq >= 32)
-		z_irq_spurious(NULL);
+	while (irq) {
+		/*
+		 * If the IRQ is out of range, call z_irq_spurious.
+		 * A call to z_irq_spurious will not return.
+		 */
+		if (irq == 0U || irq >= 32)
+			z_irq_spurious(NULL);
 
-	/*
-	 * xlnx_intc_irq_pending is returning values >= 1 but because it is second level offset
-	 * needs to be found and _sw_isr_table starting from 0 not 1.
-	 */
-	irq -= 1;
+		/*
+		 * xlnx_intc_irq_pending is returning values >= 1 but because it is second level offset
+		 * needs to be found and _sw_isr_table starting from 0 not 1.
+		 */
+		irq -= 1;
 
-	/* Apply level offset from registration as primary or secondary controller */
-	irq += level;
+		/* Apply level offset from registration as primary or secondary controller */
+		irq += level;
 
-	/* Call the corresponding IRQ handler in _sw_isr_table */
-	ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
+		/* Call the corresponding IRQ handler in _sw_isr_table */
+		ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
 
-	/* Table is already filled by z_irq_spurious calls that's why likely save to call it */
-	ite->isr(ite->arg);
+		/* Table is already filled by z_irq_spurious calls that's why likely save to call it */
+		ite->isr(ite->arg);
 
-	/* When IRQ is handled and solved by driver, irq should be ACK to interrupt controller */
-	xlnx_intc_irq_acknowledge(irq_mask);
+		/* Service the next IRQ */
+		irq_mask &= ~(1U << (irq - level));
+		irq = find_lsb_set(irq_mask);
+	}
+
+	/* When IRQs are handled and solved by driver, IRQs should be ACK to interrupt controller */
+	xlnx_intc_irq_acknowledge(irq_pending);
 }
 
 static int xlnx_intc_init(const struct device *dev)


### PR DESCRIPTION
# Fix AXI Interrupt Controller (INTC) interrupt handling

## Description

The interrupt controller interrupt handler function
`static void xlnx_irq_handler()` in
`zephyr/drivers/interrupt_controller/intc_xlnx.c:188`
serves only the highest priority interrupt.
If there are multiple pending interrupts,
it doesn't handle the others' ISRs.

## Example

When using SPI-controlled flash and using the flash test shell command `flash test flash@0 0x0 0x1000 0x3e8` with `CONFIG_FLASH_SHELL=y` enabled, sometimes fails to a DTR empty timeout error. This is caused by not handling the ISR for the AXI Quad SPI even though it was pending due to it having a lower priority than the timer or the UART interrupts.

<img width="1004" height="856" alt="image" src="https://github.com/user-attachments/assets/b87c1c87-a271-479a-8172-ff3d42144117" />

## Fix

Fix the issue by handling all the ISRs based on
all the pending interrupts in the function.

<img width="316" height="503" alt="image" src="https://github.com/user-attachments/assets/a86d23fc-fcd3-476e-afd0-50aecb6fcf9f" />